### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ name: Maven and Python Tests
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
Potential fix for [https://github.com/qdrant/qdrant-spark/security/code-scanning/2](https://github.com/qdrant/qdrant-spark/security/code-scanning/2)

To fix this problem, you should add a minimal `permissions` block limiting the GITHUB_TOKEN access. For this workflow, set `permissions: contents: read` at the `jobs.test` level (immediately underneath the job name, before `strategy:`). This ensures that only read access to repository contents is allowed, aligning with the principle of least privilege and addressing the flagged warning. No additional dependencies or outside code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
