### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/qdrant/qdrant-spark/security/code-scanning/1](https://github.com/qdrant/qdrant-spark/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to restrict the default permissions of the `GITHUB_TOKEN` to the minimum required. This can be done at the workflow root (applies to all jobs) or at the individual job level. The semantic-release step, which creates releases and tags, requires `contents: write`. If the workflow only needs to publish GitHub releases and interact with repository contents, `contents: write` is sufficient. Therefore, insert a `permissions:` block with `contents: write` at the workflow root, above the `on:` key. No other permission is needed unless a job also interacts with issues, pull requests, or other GitHub resources (which is not shown in the snippet).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
