### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      version-updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      version-updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Dependabot Configuration

Adds automated dependency management via Dependabot.

### Detected ecosystems

- `maven`
- `github-actions`

### Configuration
- **Schedule:** weekly
- **PR limit:** 5 per ecosystem
- **Grouping:** security updates grouped together, minor/patch version updates grouped together, major updates ungrouped
- **Target branch:** `master`

### What to expect
- Dependabot will open PRs for dependency updates based on the schedule above
- Security updates are prioritized and grouped separately
- Major version updates appear as individual PRs (may have breaking changes)

Customize this config after merging if your repo has specific needs (e.g., custom registries, multiple directories, ignore rules).